### PR TITLE
Add V-SYNC to all video modes

### DIFF
--- a/video.c
+++ b/video.c
@@ -4007,7 +4007,7 @@ void init_video()
 
   warm_change_cb_upper(WCB_C_BIT|WCB_B_BIT, 1);
 #else
-  rl_screen = SDL_SetVideoMode(320 * video_scale, 240 * video_scale, 16, SDL_HWSURFACE);
+  rl_screen = SDL_SetVideoMode(320 * video_scale, 240 * video_scale, 16, SDL_HWSURFACE | SDL_DOUBLEBUF);
   screen = SDL_CreateRGBSurface(SDL_SWSURFACE, 240 * video_scale, 160 * video_scale, 16, 0, 0, 0, 0);
   //screen = SDL_SetVideoMode(240 * video_scale, 160 * video_scale, 16, 0);
 #endif
@@ -4246,7 +4246,7 @@ void video_resolution_large()
 #else
   resolution_width = 320;
   resolution_height = 240;
-  rl_screen = SDL_SetVideoMode(resolution_width * video_scale, resolution_height * video_scale, 16, SDL_HWSURFACE);
+  rl_screen = SDL_SetVideoMode(resolution_width * video_scale, resolution_height * video_scale, 16, SDL_HWSURFACE | SDL_DOUBLEBUF);
   screen = SDL_CreateRGBSurface(SDL_SWSURFACE, resolution_width * video_scale, resolution_height * video_scale, 16, 0, 0, 0, 0);
   /*screen = SDL_SetVideoMode(320, 240, 16, 0);*/
 
@@ -4282,7 +4282,7 @@ void video_resolution_small()
 
   warm_change_cb_upper(WCB_C_BIT|WCB_B_BIT, 1);
 #else
-  rl_screen = SDL_SetVideoMode(320 * video_scale, 240 * video_scale, 16, SDL_HWSURFACE);
+  rl_screen = SDL_SetVideoMode(320 * video_scale, 240 * video_scale, 16, SDL_HWSURFACE | SDL_DOUBLEBUF);
   screen = SDL_CreateRGBSurface(SDL_SWSURFACE, 320 * video_scale, 240 * video_scale, 16, 0, 0, 0, 0);
   /*screen = SDL_SetVideoMode(small_resolution_width * video_scale,
    small_resolution_height * video_scale, 16, 0);*/

--- a/video.c
+++ b/video.c
@@ -3591,7 +3591,7 @@ static inline void gba_nofilter_upscale(uint16_t *dst, uint16_t *src, int h)
     dst += ((240-h)/2) * 320;  // blank upper border. h=240(full) or h=214(aspect)
 
     int x, y;
-    for (y = 0; y < 240; y++)
+    for (y = 0; y < h; y++)
     {
         int source = dh * width;
         for (x = 0; x < 320/4; x++)


### PR DESCRIPTION
Adding SDL_DOUBLEBUF in SDL_SetVideoMode() greatly reduces screen tearing on Miyoo devices.

_The video driver did not open double buffering, and then handed it over to SDL for processing_ (by @steward-fu).

Latest filtering method with ``Screen Filtering->OFF`` in emu needed small fix for aspect scaled image to display correctly (thanks to _drowsnug_ for finding).