### PR TITLE
Restore "overlay" (borders) functionality

### DIFF
--- a/video.c
+++ b/video.c
@@ -4290,9 +4290,7 @@ void video_resolution_small()
   resolution_width = small_resolution_width;
   resolution_height = small_resolution_height;
   
-  switch(current_scale){
-  case unscaled:
-    {
+  if (screen_scale == unscaled){
       char name[128]={0};
       SDL_Surface *loadPNG(const char* Path, uint32_t MaxWidth, uint32_t MaxHeight);
       sprintf(name, "%s/border.png", main_path);
@@ -4305,10 +4303,6 @@ void video_resolution_small()
       SDL_BlitSurface(png, NULL, rl_screen, NULL);
       SDL_Flip(rl_screen);
       SDL_FreeSurface(png);
-    }
-    break;
-  default:
-    break;
   }
 }
 

--- a/video.c
+++ b/video.c
@@ -4290,7 +4290,26 @@ void video_resolution_small()
   resolution_width = small_resolution_width;
   resolution_height = small_resolution_height;
   
-  SDL_FillRect(rl_screen, NULL, 0);
+  switch(current_scale){
+  case unscaled:
+    {
+      char name[128]={0};
+      SDL_Surface *loadPNG(const char* Path, uint32_t MaxWidth, uint32_t MaxHeight);
+      sprintf(name, "%s/border.png", main_path);
+      SDL_Surface* png = loadPNG(name, GCW0_SCREEN_WIDTH, GCW0_SCREEN_HEIGHT);
+      if(png == NULL){
+        printf("failed to load border png\n");
+      }
+      SDL_BlitSurface(png, NULL, rl_screen, NULL);
+      SDL_Flip(rl_screen);
+      SDL_BlitSurface(png, NULL, rl_screen, NULL);
+      SDL_Flip(rl_screen);
+      SDL_FreeSurface(png);
+    }
+    break;
+  default:
+    break;
+  }
 }
 
 void set_gba_resolution(video_scale_type scale)


### PR DESCRIPTION
This brings back "borders" feature to this port thus triggering overlay image over unscaled video screen with ``border.png`` put inside ./gpsp directory (set ``Display scalling->scaled 3:2``).

* Overlay sampel:
![border](https://user-images.githubusercontent.com/94932128/176036673-cddf6faa-b021-4fb0-a73c-2c640b265ef2.png)

* Package:
[borders.zip](https://github.com/rik-smeets/gpsp/files/8995656/borders.zip)

